### PR TITLE
fix(): base64 encode origin to bypass cloudfront blocking

### DIFF
--- a/src/filePicker.ts
+++ b/src/filePicker.ts
@@ -49,7 +49,7 @@ export class FilePicker {
         }
         const url = `${this.#baseUrl}/embedded/files_picker?token=${
             this.#sessionToken
-        }&origin=${window.origin}`;
+        }&origin=${btoa(window.origin)}`;
 
         this.#iframe.src = url;
     }


### PR DESCRIPTION
# (optional) Context

## Checklist

Use the checklist below as a guide to ensure your PR is ready for review

- [ ] 📝 PR has description (comment /describe to generate a description via the PR agent)
- [ ] 🧪 PR includes tests
- [ ] 🪵 PR includes logs
- [ ] 📸 PR includes screenshots demonstrating the impact (eg: UI screenshots, stack diffs, perf improvements etc.)
- [ ] 📜 Docs have been updated where relevant (eg: README.md, [docs.stackone.com](http://docs.stackone.com/ "http://docs.stackone.com"), [hub.stackone.com](http://hub.stackone.com/ "http://hub.stackone.com") etc.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved security when opening the file picker by encoding the origin parameter in the iframe URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->